### PR TITLE
Some quick fixes

### DIFF
--- a/PalettePlus/Interface/Components/NameInput.cs
+++ b/PalettePlus/Interface/Components/NameInput.cs
@@ -10,7 +10,7 @@ namespace PalettePlus.Interface.Components {
 			var result = false;
 
 			ImGui.InputTextWithHint("##NewSaveName", "Palette Name", ref name, 100);
-			if (ImGui.IsKeyDown(ImGuiKey.Enter) && name.Length > 0) {
+			if ((ImGui.IsKeyDown(ImGuiKey.Enter) || ImGui.IsKeyDown(ImGuiKey.KeypadEnter)) && name.Length > 0) {
 				var _name = name; // CS1628
 				var exists = PalettePlus.Config.SavedPalettes.Any(p => p.Name == _name && p != cur);
 				err = exists ? "a palette with this name already exists." : null;

--- a/PalettePlus/Interface/Windows/Tabs/PersistEdit.cs
+++ b/PalettePlus/Interface/Windows/Tabs/PersistEdit.cs
@@ -45,8 +45,8 @@ namespace PalettePlus.Interface.Windows.Tabs {
 
 		private void DrawRow(Persist persist, bool add = false) {
 			if (add) {
-                ImGui.BeginDisabled(string.IsNullOrEmpty(Persist.Character) || string.IsNullOrEmpty(Persist.PaletteId));
-                if (ImGuiComponents.IconButton(PersistIndex, FontAwesomeIcon.Plus)) {
+				ImGui.BeginDisabled(string.IsNullOrEmpty(Persist.Character) || string.IsNullOrEmpty(Persist.PaletteId));
+				if (ImGuiComponents.IconButton(PersistIndex, FontAwesomeIcon.Plus)) {
 					PalettePlus.Config.Persistence.Add(persist);
 					Persist = new();
 				}

--- a/PalettePlus/Interface/Windows/Tabs/PersistEdit.cs
+++ b/PalettePlus/Interface/Windows/Tabs/PersistEdit.cs
@@ -37,7 +37,7 @@ namespace PalettePlus.Interface.Windows.Tabs {
 
 			PersistIndex = 0;
 
-			foreach (var persist in PalettePlus.Config.Persistence)
+			foreach (var persist in PalettePlus.Config.Persistence.ToArray())
 				DrawRow(persist);
 
 			DrawRow(Persist, true);
@@ -45,10 +45,12 @@ namespace PalettePlus.Interface.Windows.Tabs {
 
 		private void DrawRow(Persist persist, bool add = false) {
 			if (add) {
-				if (ImGuiComponents.IconButton(PersistIndex, FontAwesomeIcon.Plus)) {
+                ImGui.BeginDisabled(string.IsNullOrEmpty(Persist.Character) || string.IsNullOrEmpty(Persist.PaletteId));
+                if (ImGuiComponents.IconButton(PersistIndex, FontAwesomeIcon.Plus)) {
 					PalettePlus.Config.Persistence.Add(persist);
 					Persist = new();
 				}
+				ImGui.EndDisabled();
 			} else {
 				ImGui.Checkbox($"##PersistEnabled{PersistIndex}", ref persist.Enabled);
 			}


### PR DESCRIPTION
### Changes

- Clone the persistence configuration to avoid modifying the original while iterating.
- Grey out the create new persistence button if the fields have not been filled in yet.
- Also check for `ImGuiKey.KeypadEnter` for the palette name input (this was a personal preference, lmk if you don't want it)