### PR TITLE
Improve HDR color handling

### DIFF
--- a/PalettePlus/Extensions/Vector.cs
+++ b/PalettePlus/Extensions/Vector.cs
@@ -3,25 +3,35 @@ using System.Numerics;
 
 namespace PalettePlus.Extensions {
 	internal static class VectorExtensions {
+		private static float RgbSqrt(float x)
+			=> x < 0.0f ? -MathF.Sqrt(-x) : MathF.Sqrt(x);
+
 		internal static Vector3 RgbSqrt(this Vector3 vec) => new(
-			(float)Math.Sqrt(vec.X),
-			(float)Math.Sqrt(vec.Y),
-			(float)Math.Sqrt(vec.Z)
+			RgbSqrt(vec.X),
+			RgbSqrt(vec.Y),
+			RgbSqrt(vec.Z)
 		);
 
 		internal static Vector4 RgbSqrt(this Vector4 vec) => new(
-			(float)Math.Sqrt(vec.X),
-			(float)Math.Sqrt(vec.Y),
-			(float)Math.Sqrt(vec.Z),
+			RgbSqrt(vec.X),
+			RgbSqrt(vec.Y),
+			RgbSqrt(vec.Z),
 			vec.W
 		);
 
-		internal static Vector3 RgbPow2(this Vector3 vec) => vec * vec;
+		private static float RgbPow2(float x)
+			=> x < 0.0f ? -(x * x) : x * x;
+
+		internal static Vector3 RgbPow2(this Vector3 vec) => new(
+			RgbPow2(vec.X),
+			RgbPow2(vec.Y),
+			RgbPow2(vec.Z)
+		);
 
 		internal static Vector4 RgbPow2(this Vector4 vec) => new(
-			vec.X * vec.X,
-			vec.Y * vec.Y,
-			vec.Z * vec.Z,
+			RgbPow2(vec.X),
+			RgbPow2(vec.Y),
+			RgbPow2(vec.Z),
 			vec.W
 		);
 	}

--- a/PalettePlus/Interface/Components/PaletteEditor.cs
+++ b/PalettePlus/Interface/Components/PaletteEditor.cs
@@ -128,7 +128,7 @@ namespace PalettePlus.Interface.Components {
 					
 					var alpha = field.Attributes.Any(attr => attr is ShowAlpha);
 					if (alpha) {
-						if (ImGui.ColorEdit4(label, ref vec4))
+						if (ImGui.ColorEdit4(label, ref vec4, ImGuiColorEditFlags.AlphaPreviewHalf | ImGuiColorEditFlags.HDR))
 							newVal = vec4.RgbPow2();
 					} else {
 						var vec3 = new Vector3(vec4.X, vec4.Y, vec4.Z);
@@ -137,7 +137,7 @@ namespace PalettePlus.Interface.Components {
 					}
 				} else if (data is Vector3 vec3) {
 					vec3 = vec3.RgbSqrt();
-					if (ImGui.ColorEdit3(label, ref vec3))
+					if (ImGui.ColorEdit3(label, ref vec3, ImGuiColorEditFlags.HDR))
 						newVal = vec3.RgbPow2();
 				} else if (data is float flt) {
 					var slider = (Slider?)field.Attributes.FirstOrDefault(attr => attr is Slider);


### PR DESCRIPTION
- Restore support for negative RGB values, while keeping square/sqrt-like formulae (they did it on the Anamnesis side so I guess there are people somewhere who actually use it?) ;
- Set the ImGui color fields to HDR so the user can drag the values outside the 0..255 range (which they already could by double-clicking and inputting a number by hand) ;
- Set the ARGB fields to display both the opaque and the transparent color.